### PR TITLE
escape single quotes

### DIFF
--- a/fields/field.uniqueinput.php
+++ b/fields/field.uniqueinput.php
@@ -110,7 +110,7 @@
 					$existing = Symphony::Database()->fetchRow(0, "
 						SELECT `id`, `value`, `handle`
 						FROM `tbl_entries_data_" . $this->get('id') . "`
-						WHERE `value` = '".General::sanitize($data)."'
+						WHERE `value` = '".mysql_real_escape_string(General::sanitize($data))."'
 						AND `entry_id` = {$entry_id}
 						LIMIT 1
 					");


### PR DESCRIPTION
This changes prevent a issue with single quotes when saving repeated inputs. I don't know if the Symphony framework provide a better way to do this, but this changes fix the bug.
